### PR TITLE
Fix env variable name in error message to `ORIGINS`

### DIFF
--- a/login_script.js
+++ b/login_script.js
@@ -2,7 +2,7 @@ const REQUIRED_ORIGIN_PATTERN =
   /^((\*|([\w_-]{2,}))\.)*(([\w_-]{2,})\.)+(\w{2,})(\,((\*|([\w_-]{2,}))\.)*(([\w_-]{2,})\.)+(\w{2,}))*$/
 
 if (!process.env.ORIGINS.match(REQUIRED_ORIGIN_PATTERN)) {
-  throw new Error('process.env.ORIGIN MUST be comma separated list \
+  throw new Error('process.env.ORIGINS MUST be comma separated list \
     of origins that login can succeed on.')
 }
 const origins = process.env.ORIGINS.split(',')


### PR DESCRIPTION
When the environment variable `ORIGINS` provides a value that does not match the expected format, an error message gets printed with the wrong variable name. This confused me when I ran into it, and it made me wonder whether we are setting the right variable.